### PR TITLE
renovate.json: disable for wit-bindgen

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,10 @@
     {
       "matchPackagePatterns": ["^wasmtime"],
       "enabled": false
+    },
+    {
+      "matchPackagePatterns": ["^wit-bindgen"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
* i want to manage it manually at least for now.

* there are a few more places the version is hardcoded than renovate proposes updates.