### PR TITLE
wit: retire non-doc comments

### DIFF
--- a/sensing.md
+++ b/sensing.md
@@ -164,7 +164,7 @@ Eg. frame rate for image sensors.
 <li><a name="device_error.unknown"><code>unknown</code></a></li>
 </ul>
 <h4><a name="device"><code>resource device</code></a></h4>
-<hr />
+<h2>Sensor device</h2>
 <h3>Functions</h3>
 <h4><a name="static_device.open"><code>[static]device.open: func</code></a></h4>
 <p>open the device.

--- a/wit/sensor.wit
+++ b/wit/sensor.wit
@@ -22,7 +22,7 @@ interface sensor {
       unknown
   }
 
-  // Sensor device
+  /// Sensor device
   resource device {
       /// open the device.
       /// this might power on the device.

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -1,10 +1,3 @@
-// If the repository defines `interface`s, this file can define a minimal world
-// which contains those interfaces, to allow documentation to be generated for
-// them.
-//
-// Proposals should remove these `//` commments, and edit the `world` name and
-// imports below to pull in their own `interface`s.
-
 package wasi:sensor;
 
 world sensing {


### PR DESCRIPTION
wit-parser 1.3.1 contains a breaking change [1], which
made our CI fail with "found doc comments on multiple 'package' items".
(i guess they should not have made such a breaking change in
a patch version.)

as the wit spec is going to retire non-doc comments,
this commit retires all non-doc comments in our wit files.
(either by removing them or switching them to doc comments.)

[1] https://github.com/bytecodealliance/wasm-tools/pull/1357
