### PR TITLE
host_wasmtime/Cargo.toml: exact match wasmtime version

### DIFF
--- a/.github/workflows/wasmtime.yml
+++ b/.github/workflows/wasmtime.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
     runs-on: ${{matrix.os}}
 
     steps:

--- a/host_wasmtime/Cargo.toml
+++ b/host_wasmtime/Cargo.toml
@@ -26,5 +26,5 @@ async-trait = "0.1.77"
 tokio = { version = "1.37.0", default-features = false }
 
 # preview2 and component-model are still moving targets.
-wasmtime = { version = "17.0.2", default-features = false, features = ["component-model", "cranelift"]}
-wasmtime-wasi = { version = "17.0.2", default-features = false, features = ["preview2", "sync"] }
+wasmtime = { version = "=17.0.2", default-features = false, features = ["component-model", "cranelift"]}
+wasmtime-wasi = { version = "=17.0.2", default-features = false, features = ["preview2", "sync"] }


### PR DESCRIPTION
it seems that precompiled modules are incompatible among patch versions.